### PR TITLE
introduce error-prone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
             <target>7</target>
             <encoding>${project.build.sourceEncoding}</encoding>
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
+            <showWarnings>true</showWarnings>
           </configuration>
           <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,24 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.3</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <compilerId>javac-with-errorprone</compilerId>
+            <source>7</source>
+            <target>7</target>
             <encoding>${project.build.sourceEncoding}</encoding>
+            <forceJavacCompilerUse>true</forceJavacCompilerUse>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.plexus</groupId>
+              <artifactId>plexus-compiler-javac-errorprone</artifactId>
+              <version>2.5</version>
+            </dependency>
+            <dependency>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>2.0.9</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
             <dependency>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
-              <version>2.0.9</version>
+              <version>2.0.5</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/test-case/pom.xml
+++ b/test-case/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.12.2</version>
+      <version>1.16.8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
to use with lombok, we should use the latest version of lombok
which supports Java9.
https://github.com/google/error-prone/issues/347