### PR TITLE
Support SpotBugs 3.1.5, and the build on JDK9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,3 +120,7 @@
 
 - Upgrade findbugs-maven-plugin to spotbugs-maven-plugin
 - Upgrade several dependencies
+
+## 1.4.1
+
+- Upgrade maven-javadoc-plugin, lombok and errorprone to avoid NullPointerException and ExceptionInInitializerError

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,4 @@
 ## 1.4.1
 
 - Upgrade maven-javadoc-plugin, lombok and errorprone to avoid NullPointerException and ExceptionInInitializerError
+- Support SpotBugs 3.1.5 that deletes several constant fields

--- a/bug-pattern/src/main/java/jp/skypencil/findbugs/slf4j/IllegalPassedClassDetector.java
+++ b/bug-pattern/src/main/java/jp/skypencil/findbugs/slf4j/IllegalPassedClassDetector.java
@@ -1,5 +1,10 @@
 package jp.skypencil.findbugs.slf4j;
 
+import static org.apache.bcel.Const.CONSTANT_Class;
+import static org.apache.bcel.Const.INVOKESTATIC;
+import static org.apache.bcel.Const.INVOKEVIRTUAL;
+import static org.apache.bcel.Const.LDC;
+import static org.apache.bcel.Const.LDC_W;
 import static org.apache.bcel.Repository.lookupClass;
 
 import com.google.common.base.Objects;

--- a/bug-pattern/src/main/java/jp/skypencil/findbugs/slf4j/ManualMessageDetector.java
+++ b/bug-pattern/src/main/java/jp/skypencil/findbugs/slf4j/ManualMessageDetector.java
@@ -1,5 +1,7 @@
 package jp.skypencil.findbugs.slf4j;
 
+import static org.apache.bcel.Const.INVOKEVIRTUAL;
+
 import com.google.common.base.Objects;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;

--- a/bug-pattern/src/main/java/jp/skypencil/findbugs/slf4j/parameter/AbstractDetectorForParameterArray.java
+++ b/bug-pattern/src/main/java/jp/skypencil/findbugs/slf4j/parameter/AbstractDetectorForParameterArray.java
@@ -1,5 +1,9 @@
 package jp.skypencil.findbugs.slf4j.parameter;
 
+import static org.apache.bcel.Const.INVOKEINTERFACE;
+import static org.apache.bcel.Const.INVOKESTATIC;
+import static org.apache.bcel.Const.INVOKEVIRTUAL;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.collect.ArrayListMultimap;

--- a/pom.xml
+++ b/pom.xml
@@ -66,17 +66,24 @@
             <encoding>${project.build.sourceEncoding}</encoding>
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
             <showWarnings>true</showWarnings>
+            <compilerArgs>
+              <!--
+                workaround to avoid the bug in errorprone
+                https://github.com/google/error-prone/issues/780#issuecomment-357952383
+              -->
+              <arg>-Xep:ParameterName:OFF</arg>
+            </compilerArgs>
           </configuration>
           <dependencies>
             <dependency>
               <groupId>org.codehaus.plexus</groupId>
               <artifactId>plexus-compiler-javac-errorprone</artifactId>
-              <version>2.5</version>
+              <version>2.8.3</version>
             </dependency>
             <dependency>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
-              <version>2.0.5</version>
+              <version>2.3.1</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -126,7 +133,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
+          <version>3.0.1</version>
         </plugin>
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
@@ -152,7 +159,7 @@
           </execution>
         </executions>
         <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <doclint>none</doclint>
         </configuration>
       </plugin>
       <plugin>
@@ -293,7 +300,7 @@
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.16.18</version>
+        <version>1.18.0</version>
         <scope>provided</scope>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spotbugs.version>3.1.0</spotbugs.version>
+    <spotbugs.version>3.1.5</spotbugs.version>
     <spotless.version>1.0.0.BETA5</spotless.version>
     <version.slf4j>1.7.25</version.slf4j>
     <jacoco.skip>true</jacoco.skip>


### PR DESCRIPTION
SpotBugs 3.1.5 deleted several constant fields, so detectors need to be updated.

* https://github.com/spotbugs/spotbugs/pull/652
* https://github.com/spotbugs/spotbugs/pull/656