### PR TITLE
Bump maven surefire plugin from 2.19 to 2.22.0 and junit platform surefire provider from 1.0.0 to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19</version>
+          <version>2.22.0</version>
           <dependencies>
             <dependency>
               <groupId>org.junit.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
             <dependency>
               <groupId>org.junit.platform</groupId>
               <artifactId>junit-platform-surefire-provider</artifactId>
-              <version>1.0.0</version>
+              <version>1.2.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
If only update surefire-provider, NoSuchMethodError occurred

Based: #81 