### PR TITLE
stop running sonarqube analysis on the PR made from forked repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
 jobs:
   include:
     - stage: analysis
-      if: fork = false
+      if: ( type = pull_request and head_repo =~ ^KengoTODA/ ) or ( type != pull_request and repo =~ ^KengoTODA/ )
       script:
         - ./mvnw org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -Dgpg.skip -B
 notifications:


### PR DESCRIPTION
by this `if`, we limit sonarqube analysis only in following cases:
1. pull requests that uses the KengoTODA account as HEAD branch, or
2. other type of build that runs in the KengoTODA account